### PR TITLE
Add support of proxies

### DIFF
--- a/meta/recipes-devtools/buildchroot/files/setup.sh
+++ b/meta/recipes-devtools/buildchroot/files/setup.sh
@@ -66,3 +66,6 @@ sudo chmod -R a+rw $TARGET/home/builder
 
 # Install host networking settings
 sudo cp /etc/resolv.conf $TARGET/etc
+
+# Pass proxy settings in apt config
+sudo sh -c "apt-config dump | grep 'Acquire::.*::proxy' > $TARGET/etc/apt/apt.conf.d/01proxy"


### PR DESCRIPTION
This pull request includes a commit to build isar in proxy network.
The commit is compatible with the master branch.

How it was tested:
1. Add proxy settings into the native apt config
`# echo 'Acquire::http::proxy "http://my.proxy.server";' > /etc/apt/apt.conf.d/proxy`
2. Bitbake isar-image-base
