### PR TITLE
doc: Change <CONFIG> to ${CONFIG} in user_manual.md

### DIFF
--- a/doc/user_manual.md
+++ b/doc/user_manual.md
@@ -401,7 +401,7 @@ If BitBake is called with multiconfig targets (e.g.,
 all supported configurations:
 
  - `BBMULTICONFIG` - The list of the complete configuration definition files.
-   BitBake looks for conf/multiconfig/${MACHINE}.conf in every layer. Every
+   BitBake looks for conf/multiconfig/${CONFIG}.conf in every layer. Every
    configuration must define `MACHINE`, `DISTRO` and `DISTRO_ARCH`.
 
 Some other variables include:

--- a/doc/user_manual.md
+++ b/doc/user_manual.md
@@ -401,7 +401,7 @@ If BitBake is called with multiconfig targets (e.g.,
 all supported configurations:
 
  - `BBMULTICONFIG` - The list of the complete configuration definition files.
-   BitBake looks for conf/multiconfig/<CONFIG>.conf in every layer. Every
+   BitBake looks for conf/multiconfig/${MACHINE}.conf in every layer. Every
    configuration must define `MACHINE`, `DISTRO` and `DISTRO_ARCH`.
 
 Some other variables include:


### PR DESCRIPTION
While using <CONFIG>.conf, it will generate only ".conf" as "conf/multiconfig/.conf", so change <CONFIG> to ${MACHINE} in user_manual.md