### PR TITLE
fixed 2 typos in RECIPE-API-CHANGELOG.md (due to 87d31ee)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 /*.patch
 __pycache__
+.gitpasswd

--- a/RECIPE-API-CHANGELOG.md
+++ b/RECIPE-API-CHANGELOG.md
@@ -428,3 +428,16 @@ It was never intended to also deploy those partitions, so that will also not be 
 To explicitly deploy the individual partition files (e.g. for swupdate), set `WIC_DEPLOY_PARTITIONS = "1"`.
 
 For compressed wic images `IMAGE_FSTYPES` should simply be extended with a compressed wic format, like "wic.xz".
+
+### Introduce mechanism to forward bitbake variables into sbuild environment
+
+All recipes that inherit from dpkg can use the bitbake variable `SBUILD_PASSTHROUGH_ADDITIONS` to forward
+specific bitbake variables as environment variables into the sbuild environment.
+The motivation behind it is to allow the use of external mirrors for programming languages with builtin
+package managers (like rust and go). By that, the variables are also excluded from the bitbake signatures.
+This helps in areas where default mirrors can either not be reached or provide only little throughput.
+Please note, the forwarded variables do not have to exist. While they are not forwared in case they do not
+exist, empty variables are forwarded.
+
+**Note about reproducability**: the forwarded variables must not have any influence on the generated package.
+This mechanism must also not be used to inject build configurations. For these cases, templates should be used.

--- a/RECIPE-API-CHANGELOG.md
+++ b/RECIPE-API-CHANGELOG.md
@@ -436,8 +436,8 @@ specific bitbake variables as environment variables into the sbuild environment.
 The motivation behind it is to allow the use of external mirrors for programming languages with builtin
 package managers (like rust and go). By that, the variables are also excluded from the bitbake signatures.
 This helps in areas where default mirrors can either not be reached or provide only little throughput.
-Please note, the forwarded variables do not have to exist. While they are not forwared in case they do not
+Please note, the forwarded variables do not have to exist. While they are not forwarded in case they do not
 exist, empty variables are forwarded.
 
-**Note about reproducability**: the forwarded variables must not have any influence on the generated package.
+**Note about reproducibility**: the forwarded variables must not have any influence on the generated package.
 This mechanism must also not be used to inject build configurations. For these cases, templates should be used.

--- a/meta/classes/image.bbclass
+++ b/meta/classes/image.bbclass
@@ -440,7 +440,7 @@ do_rootfs_quality_check() {
     rootfs_install_stamp=$( ls -1 "${STAMP}".do_rootfs_install* | head -1 )
     test -f "$rootfs_install_stamp"
 
-    args="$ROOTFS_QA_FIND_ARGS"
+    args="${ROOTFS_QA_FIND_ARGS}"
     # rootfs_finalize chroot-setup.sh
     args="${args} ! -path ${ROOTFSDIR}/var/lib/dpkg/diversions"
     for cmd in ${ROOTFS_POSTPROCESS_COMMAND}; do

--- a/testsuite/start_vm.py
+++ b/testsuite/start_vm.py
@@ -70,6 +70,10 @@ def format_qemu_cmdline(arch, build, distro, out, pid, enforce_pcbios=False):
         bios_idx = qemu_disk_args.index('-bios')
         del qemu_disk_args[bios_idx : bios_idx+2]
 
+    # Support SSH access from host via port 22222
+    extra_args.extend(['-device', 'e1000,netdev=net0'])
+    extra_args.extend(['-netdev', 'user,id=net0,hostfwd=tcp::22222-:22'])
+
     cmd = ['qemu-system-' + qemu_arch, '-m', '1024M']
 
     if qemu_machine:


### PR DESCRIPTION
bugfix, typos, documentation

87d31ee: add interface to passthrough env vars to sbuild

Signed-off-by: Roberto A. Foglietta <roberto.foglietta@gmail.com>
