### PR TITLE
meta/classes/rootfs.bbclass:systemd-resolved fix build issue

### DIFF
--- a/meta/classes/rootfs.bbclass
+++ b/meta/classes/rootfs.bbclass
@@ -134,6 +134,9 @@ rootfs_install_resolvconf[weight] = "1"
 rootfs_install_resolvconf() {
     if [ "${@repr(bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')))}" != "True" ]
     then
+        if [ -L "${ROOTFSDIR}/etc/resolv.conf" ]; then
+            sudo unlink "${ROOTFSDIR}/etc/resolv.conf"
+        fi
         sudo cp -rL /etc/resolv.conf '${ROOTFSDIR}/etc'
     fi
 }


### PR DESCRIPTION
building images with systemd-resolved package installed in chroot,fails due to dangling symlink error as there is pre existing symlink for /etc/resolv.conf created by installation of systemd-resolved.So we need to ensure to unlink and symlink existing for /etc/resolv.conf.

Signed-off-by: Shivaschandra K L <shivaschandra.k-l@siemens.com>