### PR TITLE
python3-setuptools integrated in manual.md

### DIFF
--- a/doc/user_manual.md
+++ b/doc/user_manual.md
@@ -107,6 +107,11 @@ If your host is >= buster, also install the following package.
 apt install python3-distutils
 ```
 
+The python3-distutils is deprecated and was replaced with python3-setuptools. If your apt complains about not finding python3-distutils, try the following instead:
+```
+apt install python3-setuptools
+```
+
 **NOTE:** sbuild version (<=0.78.1) packaged in Debian Buster doesn't support
 `$apt_keep_downloaded_packages` option which is required in Isar for
 populating `${DL_DIR}/deb`. So, host `sbuild` in this case should be manually


### PR DESCRIPTION
While testing on Ubuntu 24.10 I realized that python3-distutils can not be installed. Using apt install python3-setuptools is working. I added this to the manual, to help other users circumvent this problem